### PR TITLE
Update endpoints.md to correct a issue within the availability url

### DIFF
--- a/external-api/endpoints.md
+++ b/external-api/endpoints.md
@@ -125,7 +125,7 @@ Returns an array of `Availability` objects.
 
 Example request:
 
-    $ curl -H "X-FareHarbor-API-App: YOUR-APP-KEY" -H "X-FareHarbor-API-User: YOUR-USER-KEY" https://fareharbor.com/api/external/v1/companies/hawaiianadventures/items/1867/availabilities/date/2015-01-022/
+    $ curl -H "X-FareHarbor-API-App: YOUR-APP-KEY" -H "X-FareHarbor-API-User: YOUR-USER-KEY" https://fareharbor.com/api/external/v1/companies/hawaiianadventures/items/1867/availabilities/date/2015-01-22/
 
 Example response:
 


### PR DESCRIPTION
The availability URL has an incorrect date format causing a return status of 404 "Unsupported URL". Simply removing the prefixed 0 from the day corrects the issue.