### PR TITLE
updated python example to python3

### DIFF
--- a/examples/python.md
+++ b/examples/python.md
@@ -31,7 +31,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
 
     companies_url = '%s/companies/' % ROOT_URL
     
-    print companies_url
+    print(companies_url)
 
     response = requests.get(companies_url, headers=HEADERS)
 
@@ -39,7 +39,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
     companies = response_data['companies']
 
     for company in companies:
-        print company
+        print(company)
 
 # Listing items for a company
 
@@ -47,7 +47,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
     
     items_url = '%s/companies/%s/items/' % (ROOT_URL, company['shortname'],)
     
-    print items_url
+    print(items_url)
 
     response = requests.get(items_url, headers=HEADERS)
 
@@ -55,7 +55,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
     items = response_data['items']
 
     for item in items:
-        print item
+        print(item)
         
 # Listing availabilities for an item
 
@@ -67,7 +67,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
         item['pk'],
     )
     
-    print availabilities_url
+    print(availabilities_url)
     
     response = requests.get(availabilities_url, headers=HEADERS)
     
@@ -75,7 +75,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
     availabilities = response_data['availabilities']
     
     for availability in availabilities:
-        print availability
+        print(availability)
         
 # Listing customer type rates for an availability
 
@@ -84,7 +84,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
     customer_type_rates = availability['customer_type_rates']
     
     for customer_type_rate in customer_type_rates:
-        print customer_type_rate
+        print(customer_type_rate)
         
 # Creating a booking for an availability
 
@@ -96,7 +96,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
         availability['pk'],
     )
     
-    print book_url
+    print(book_url)
     
     request_data = {
         'contact': {
@@ -119,7 +119,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
     response_data = json.loads(response.text)
     booking = response_data['booking']
     
-    print booking
+    print(booking)
     
 # Retrieving a booking
 
@@ -129,14 +129,14 @@ http://docs.python-requests.org/en/latest/user/install/#install
         booking['uuid'],
     )
 
-    print booking_url
+    print(booking_url)
 
     response = requests.get(booking_url, headers=HEADERS)
     
     response_data = json.loads(response.text)
     booking = response_data['booking']
         
-    print booking
+    print(booking)
     
 # Entire script
 
@@ -157,7 +157,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
 
     companies_url = '%s/companies/' % ROOT_URL
 
-    print companies_url
+    print(companies_url)
 
     response = requests.get(companies_url, headers=HEADERS)
 
@@ -165,7 +165,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
     companies = response_data['companies']
 
     for company in companies:
-        print company
+        print(company)
 
     # ITEMS
 
@@ -173,7 +173,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
 
     items_url = '%s/companies/%s/items/' % (ROOT_URL, company['shortname'],)
 
-    print items_url
+    print(items_url)
 
     response = requests.get(items_url, headers=HEADERS)
 
@@ -181,7 +181,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
     items = response_data['items']
 
     for item in items:
-        print item
+        print(item)
 
     # AVAILABILITIES
 
@@ -193,7 +193,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
         item['pk'],
     )
 
-    print availabilities_url
+    print(availabilities_url)
 
     response = requests.get(availabilities_url, headers=HEADERS)
 
@@ -201,7 +201,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
     availabilities = response_data['availabilities']
 
     for availability in availabilities:
-        print availability
+        print(availability)
 
     # CUSTOMER TYPE RATES
 
@@ -210,7 +210,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
     customer_type_rates = availability['customer_type_rates']
 
     for customer_type_rate in customer_type_rates:
-        print customer_type_rate
+        print(customer_type_rate)
 
     # CREATE BOOKING
 
@@ -222,7 +222,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
         availability['pk'],
     )
 
-    print book_url
+    print(book_url)
 
     request_data = {
         'contact': {
@@ -244,7 +244,7 @@ http://docs.python-requests.org/en/latest/user/install/#install
     response_data = json.loads(response.text)
     booking = response_data['booking']
 
-    print booking
+    print(booking)
 
     # RETRIEVE BOOKING
 
@@ -254,11 +254,11 @@ http://docs.python-requests.org/en/latest/user/install/#install
         booking['uuid'],
     )
 
-    print booking_url
+    print(booking_url)
 
     response = requests.get(booking_url, headers=HEADERS)
 
     response_data = json.loads(response.text)
     booking = response_data['booking']
 
-    print booking
+    print(booking)

--- a/external-api/data-types.md
+++ b/external-api/data-types.md
@@ -365,6 +365,27 @@ Example:
 
   The location's TripAdvisor URL.
 
+Example:
+
+    {
+      "pk": 234234,
+      "type": "primary",
+      "note": "Next to the blue fence.",
+      "note_safe_html": "<p>Next to the blue fence.</p>",
+      "address": {
+        "city": "Honolulu",
+        "country": "US",
+        "postal_code": "96821",
+        "province": "HI",
+        "street": "123 Wailupe Cir"
+      },
+      "longitude": 21.3069,
+      "latitude": -157.8583,
+      "google_place_id": "ChIJYZ4srGUSAHwRT1Da4amp3x",
+      "tripadvisor_url": "https://www.tripadvisor.com/Attraction_Review-g60982-d184886-Reviews-Epic_Jet_Ski_Tour-Honolulu_Oahu_Hawaii.html",
+    }
+
+
 ### Cancellation Policy
 
 * `type`: `string`
@@ -393,6 +414,13 @@ Example:
 
   Note: this value can be negative indicating that bookings can be cancelled some number of hours after availability start time (when type is `hours-before-start`) or some number of hours after midnight on availability start date (when type is `hours-before-midnight`). The `cutoff_hours_before` property will provide `null` when no cutoff is applicable (when bookings are never elgible for cancellation).
 
+Example:
+
+    {
+      "type": "hours-before-start",
+      "cutoff_hours_before": "24"
+    }
+
 ### Tag
 
 * `name`: `string`
@@ -402,6 +430,13 @@ Example:
 * `short_name`: `string`
 
   The tag's short name. The short name is unique per company and is limited to lowercase letters (a-z), digits (0-9), and the dash character.
+
+Example:
+
+    {
+      "name": "Jet ski tour",
+      "short_name": "jet-ski-tour"
+    }
 
 ### Item
 
@@ -839,6 +874,12 @@ A booking can belong to an order, but it doesn't have to. An order can include a
 
   A unique identifier for the order.
 
+Example:
+
+    {
+      "display_id": "ABTT"
+    }
+
 ### Booking
 
 * `pk`: `number`
@@ -1087,6 +1128,20 @@ Extended options are applicable to custom fields of type `extended-option`.
 
   Whether the cost of this option should affect the taxable total of a booking.
 
+Example:
+
+    {
+      "pk": 105,
+      "name": "Helmet",
+      "description": "Need a helmet?",
+      "modifier_kind": "percentage",
+      "modifier_type": "adjust",
+      "offset": null,
+      "percentage": 35,
+      "is_always_per_customer": true,
+      "is_taxable": false
+    }
+
 ### Custom Field
 
 * `pk`: `number`
@@ -1123,6 +1178,28 @@ Extended options are applicable to custom fields of type `extended-option`.
   A list the custom field's extended options. This will only be provided
   for custom fields that have type `extended-option`.
 
+Example:
+
+    {
+      "pk": 4502,
+      "type": "extended-option"
+      "is_required": false,
+      "description": "Do you need additional safety equipment?",
+      "name": "Safety Equipment",
+      "offset": 100,
+      "extended_options": {
+        "pk": 105,
+        "name": "Helmet",
+        "description": "Need a helmet?",
+        "modifier_kind": "percentage",
+        "modifier_type": "adjust",
+        "offset": null,
+        "percentage": 35,
+        "is_always_per_customer": true,
+        "is_taxable": false
+      }
+    }
+
 ### Custom Field Instance
 
 * `pk`: `number`
@@ -1132,6 +1209,31 @@ Extended options are applicable to custom fields of type `extended-option`.
 * `custom_field`: `CustomField`
 
   The custom field associated with the custom field instance.
+
+Example:
+
+    {
+      "pk": 2681,
+      "custom_field": {
+        "pk": 4502,
+        "type": "yes-no"
+        "is_required": false,
+        "description": "Do you need additional safety equipment?",
+        "name": "Safety Equipment",
+        "offset": 100,
+        "extended_options": {
+          "pk": 105,
+          "name": "Helmet",
+          "description": "Need a helmet?",
+          "modifier_kind": "percentage",
+          "modifier_type": "adjust",
+          "offset": null,
+          "percentage": 35,
+          "is_always_per_customer": true,
+          "is_taxable": false
+        }
+      }
+    }
 
 ### Custom Field Value
 
@@ -1144,3 +1246,11 @@ Extended options are applicable to custom fields of type `extended-option`.
   A string up to 2048 characters. If the custom field is of type `yes-no`,
   "true" or "false" must be specified. If the custom field is of type
   `extended-option`, an extended option pk must be specified.
+
+Example:
+
+    {
+      "custom_field": 4502,
+      "value": "false",
+      "extended-option": 105
+    }


### PR DESCRIPTION
Within the python example, the main change was going from `print ...` to `print(...)` and then I tested all the example.py calls on a Python3 shell and they everything worked verbatim after the `print` change.